### PR TITLE
Create Avalonia shell for SDAT loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+bin/
+obj/
+**/bin/
+**/obj/
+*.user
+*.suo
+*.userprefs
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.tmp

--- a/NitroSynth.sln
+++ b/NitroSynth.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A3B117E6-B6F6-40A3-8C6D-20FA44150DC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NitroSynth.App", "src\NitroSynth.App\NitroSynth.App.csproj", "{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9C2902CC-C2A0-431E-B6F0-74C86A58ACB5} = {A3B117E6-B6F6-40A3-8C6D-20FA44150DC4}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # NitroSynth
+
+NitroSynth is a desktop toolchain for working with Nintendo DS Nitro Sound Archive (`.sdat`) assets. The current prototype ships a
+minimal Avalonia-based shell that can load an `.sdat` file from the menu bar and reports the selected file name and size.
+
+## Getting started
+
+### Prerequisites
+
+* .NET SDK 8.0 or newer
+
+### Build and run
+
+```bash
+dotnet build
+# or run the desktop app directly
+dotnet run --project src/NitroSynth.App
+```

--- a/src/NitroSynth.App/App.axaml
+++ b/src/NitroSynth.App/App.axaml
@@ -1,0 +1,9 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="NitroSynth.App.App"
+             RequestedThemeVariant="Default">
+    <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/src/NitroSynth.App/App.axaml.cs
+++ b/src/NitroSynth.App/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace NitroSynth.App;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/NitroSynth.App/MainWindow.axaml
+++ b/src/NitroSynth.App/MainWindow.axaml
@@ -1,0 +1,35 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:NitroSynth.App.ViewModels"
+        mc:Ignorable="d"
+        d:DesignWidth="800"
+        d:DesignHeight="450"
+        x:Class="NitroSynth.App.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="NitroSynth">
+    <Design.DataContext>
+        <vm:MainWindowViewModel />
+    </Design.DataContext>
+
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_ファイル">
+                <MenuItem Header="_開く..." Click="OnOpenSdatClicked" />
+            </MenuItem>
+        </Menu>
+
+        <Border Padding="16">
+            <StackPanel Spacing="8">
+                <TextBlock Text="NitroSynth" FontSize="20" FontWeight="SemiBold" />
+                <TextBlock Text="Nintendo DS向けNitro Sound Archive (.sdat) を読み込むには、上部メニューの『ファイル → 開く』を選択してください。"
+                           TextWrapping="Wrap" />
+                <Separator />
+                <TextBlock Text="現在の状態:" FontWeight="Bold" />
+                <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" />
+                <TextBlock Text="{Binding LoadedFilePath, TargetNullValue=''}" TextWrapping="Wrap" />
+            </StackPanel>
+        </Border>
+    </DockPanel>
+</Window>

--- a/src/NitroSynth.App/MainWindow.axaml.cs
+++ b/src/NitroSynth.App/MainWindow.axaml.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using NitroSynth.App.ViewModels;
+
+namespace NitroSynth.App;
+
+public partial class MainWindow : Window
+{
+    private readonly MainWindowViewModel _viewModel;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        _viewModel = new MainWindowViewModel();
+        DataContext = _viewModel;
+    }
+
+    private async void OnOpenSdatClicked(object? sender, RoutedEventArgs e)
+    {
+        if (StorageProvider is null)
+        {
+            return;
+        }
+
+        var options = new FilePickerOpenOptions
+        {
+            AllowMultiple = false,
+            Title = ".sdat ファイルを開く",
+            FileTypeFilter = new List<FilePickerFileType>
+            {
+                new("Nitro Sound Archive (*.sdat)")
+                {
+                    Patterns = new[] { "*.sdat" }
+                },
+                FilePickerFileTypes.All
+            }
+        };
+
+        var files = await StorageProvider.OpenFilePickerAsync(options);
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        await _viewModel.LoadSdatAsync(files[0]);
+    }
+}

--- a/src/NitroSynth.App/NitroSynth.App.csproj
+++ b/src/NitroSynth.App/NitroSynth.App.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.6" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/NitroSynth.App/Program.cs
+++ b/src/NitroSynth.App/Program.cs
@@ -1,0 +1,21 @@
+using Avalonia;
+using System;
+
+namespace NitroSynth.App;
+
+internal static class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/src/NitroSynth.App/ViewModels/MainWindowViewModel.cs
+++ b/src/NitroSynth.App/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Avalonia.Platform.Storage;
+
+namespace NitroSynth.App.ViewModels;
+
+public class MainWindowViewModel : INotifyPropertyChanged
+{
+    private const string DefaultMessage = "メニューから.sdatファイルを開いてください。";
+
+    private string _statusMessage = DefaultMessage;
+    private string? _loadedFilePath;
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetField(ref _statusMessage, value);
+    }
+
+    public string? LoadedFilePath
+    {
+        get => _loadedFilePath;
+        private set => SetField(ref _loadedFilePath, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public async Task LoadSdatAsync(IStorageFile file)
+    {
+        try
+        {
+            await using var stream = await file.OpenReadAsync();
+            var lengthText = stream.CanSeek
+                ? $" ({stream.Length:N0} バイト)"
+                : string.Empty;
+
+            LoadedFilePath = file.Path?.LocalPath ?? file.Name;
+            StatusMessage = $"読み込み完了: {file.Name}{lengthText}";
+        }
+        catch (Exception ex)
+        {
+            LoadedFilePath = file.Path?.LocalPath ?? file.Name;
+            StatusMessage = $"読み込みに失敗しました: {ex.Message}";
+        }
+    }
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+    }
+
+    private void OnPropertyChanged(string? propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/NitroSynth.App/app.manifest
+++ b/src/NitroSynth.App/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="NitroSynth.App.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## Summary
- set up a new Avalonia desktop project and solution for NitroSynth
- add a menu-based shell that opens `.sdat` files and reports the selected file information
- document basic build and run instructions for the prototype

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68ccd101b458832aabe989f658a53a2b