### PR TITLE
Fix SYMB bank table offset parsing

### DIFF
--- a/src/NitroSynth.App/Sdat/SdatParser.cs
+++ b/src/NitroSynth.App/Sdat/SdatParser.cs
@@ -112,7 +112,8 @@ public static class SdatParser
         var blockEnd = blockStart + blockSize;
 
         stream.Seek(blockStart + 8, SeekOrigin.Begin);
-        _ = reader.ReadUInt32(); // sequence table offset
+        _ = reader.ReadUInt32(); // sequence name table offset
+        _ = reader.ReadUInt32(); // sequence archive name table offset
         var bankTableOffset = reader.ReadUInt32();
 
         if (bankTableOffset == 0)


### PR DESCRIPTION
## Summary
- skip the sequence and sequence archive references before reading the SYMB bank name table so names can be resolved correctly

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cced6a6510832abda1bbcb66b0c5a7